### PR TITLE
Add Will and Ilektra to authors

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,5 +15,5 @@ authors:
     email: "william.graham@ucl.ac.uk"
     orcid: "https://orcid.org/0000-0003-0058-263X"
 repository-code: "https://github.com/NNs-FLF-RHUL/deepska"
-title: "deepSKA: A cookiecutter package with UCL ARC recommendations."
+title: "deepSKA"
 license: "GPL-3.0"


### PR DESCRIPTION
Closes issue #8 |

This updates the CITATION file with blocks for Will and Ilektra.
Also populates Vanessa's orcid field.