### PR TITLE
Fix typo in organisation name

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,6 @@ authors:
     given-names: "Will"
     email: "william.graham@ucl.ac.uk"
     orcid: "https://orcid.org/0000-0003-0058-263X"
-repository-code: "https://github.com/NNs-FLF-RHUL/deepska"
+repository-code: "https://github.com/NSs-FLF-RHUL/deepska"
 title: "deepSKA"
 license: "GPL-3.0"

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 [![License][license-badge]](./LICENSE.md)
 
 <!-- prettier-ignore-start -->
-[tests-badge]:              https://github.com/NNs-FLF-RHUL/deepska/actions/workflows/tests.yml/badge.svg
-[tests-link]:               https://github.com/NNs-FLF-RHUL/deepska/actions/workflows/tests.yml
-[linting-badge]:            https://github.com/NNs-FLF-RHUL/deepska/actions/workflows/linting.yml/badge.svg
-[linting-link]:             https://github.com/NNs-FLF-RHUL/deepska/actions/workflows/linting.yml
-[documentation-badge]:      https://github.com/NNs-FLF-RHUL/deepska/actions/workflows/docs.yml/badge.svg
-[documentation-link]:       https://github.com/NNs-FLF-RHUL/deepska/actions/workflows/docs.yml
+[tests-badge]:              https://github.com/NSs-FLF-RHUL/deepska/actions/workflows/tests.yml/badge.svg
+[tests-link]:               https://github.com/NSs-FLF-RHUL/deepska/actions/workflows/tests.yml
+[linting-badge]:            https://github.com/NSs-FLF-RHUL/deepska/actions/workflows/linting.yml/badge.svg
+[linting-link]:             https://github.com/NSs-FLF-RHUL/deepska/actions/workflows/linting.yml
+[documentation-badge]:      https://github.com/NSs-FLF-RHUL/deepska/actions/workflows/docs.yml/badge.svg
+[documentation-link]:       https://github.com/NSs-FLF-RHUL/deepska/actions/workflows/docs.yml
 [license-badge]:            https://img.shields.io/badge/License-GPLv3-blue.svg
 <!-- prettier-ignore-end -->
 
@@ -46,13 +46,13 @@ development version of `deepska` using `pip` in the currently active
 environment run
 
 ```sh
-pip install git+https://github.com/NNs-FLF-RHUL/deepska.git
+pip install git+https://github.com/NSs-FLF-RHUL/deepska.git
 ```
 
 Alternatively create a local clone of the repository with
 
 ```sh
-git clone https://github.com/NNs-FLF-RHUL/deepska.git
+git clone https://github.com/NSs-FLF-RHUL/deepska.git
 ```
 
 and then install in editable mode by running

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,8 @@ site_name: "deepSKA"
 site_description: "Documentation website for deepSKA"
 site_author: "Vanessa Graber"
 copyright: "Copyright © 2026 Vanessa Graber"
-repo_url: "https://github.com/NNs-FLF-RHUL/deepska/"
-repo_name: "NNs-FLF-RHUL/deepska"
+repo_url: "https://github.com/NSs-FLF-RHUL/deepska/"
+repo_name: "NSs-FLF-RHUL/deepska"
 edit_uri: edit/main/docs/
 
 validation:
@@ -60,4 +60,4 @@ plugins:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: "https://github.com/NNs-FLF-RHUL"
+      link: "https://github.com/NSs-FLF-RHUL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license-files = ["LICENSE.md"]
 name = "deepska"
 readme = "README.md"
 requires-python = ">=3.11"
-urls.homepage = "https://github.com/NNs-FLF-RHUL/deepska"
+urls.homepage = "https://github.com/NSs-FLF-RHUL/deepska"
 
 [project.optional-dependencies]
 dev = ["build", "mypy", "pre-commit", "ruff", "tox", "twine"]


### PR DESCRIPTION
Noticed that the organisation name was miss-spelt in a few of our configuration files, which was causing issues with the badges in the README not working, and the CITATION file links to result in 404 errors.

Ran a quick check across the package codebase for the typo (`NNs-FLF-RHUL` vs `NSs-FLF-RHUL`) and corrected the instances that it picked up. We should be good now.