### PR TITLE
Fix docs workflow failing on `main`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,14 @@ jobs:
     outputs:
       docfiles: ${{ steps.filter.outputs.docfiles }}
     steps:
+      # https://github.com/dorny/paths-filter?tab=readme-ov-file#supported-workflows
+      # When the triggering event is not a pull request, repository must be checked
+      # out prior to running, so the previous commit can be accessed and changes to
+      # the filter patterns can be detected.
+      - uses: actions/checkout@v6
+        name: (Non-pull request) Checkout repository to get commit history
+        if: ${{ github.event_name != 'pull_request' }}
+
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -82,4 +90,4 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
         with:
-          artefact_name: github-pages
+          artifact_name: github-pages


### PR DESCRIPTION
It turns out that the [action being used in the docs workflow](https://github.com/dorny/paths-filter?tab=readme-ov-file#supported-workflows) to detect changes to doc-files requires additional setup when the workflow trigger is **not** a pull request.

As such, we need to conditionally check-out the repository on non-PR triggers of this workflow, before running the `filter-paths` action. This should [fix the current failures](https://github.com/NSs-FLF-RHUL/deepSKA/actions/runs/23205781147) in the docs run on `main` (where the action complains there is no git repo to read from) whilst also retaining the intended functionality on PR branches (where the action instead just reads from the branch directly).

If this works, then we'll need to propagate these changes to the other PRs accordingly:

- [Q-Spin](https://github.com/NSs-FLF-RHUL/QSpin/pull/29#event-23652082744)
- [gains](https://github.com/NSs-FLF-RHUL/gains/pull/27#event-23652485353)
- [tingan](https://github.com/NSs-FLF-RHUL/tingan/pull/12) - will need a new PR opened, since the bug wasn't spotted until the workflow ran on `main` and failed.